### PR TITLE
DEVOPS-1491-Added-ability-to-exclude-SG-CIDRS

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ resource "aws_security_group" "main" {
 }
 
 resource "aws_security_group_rule" "allow_port_80_ingress_for_http_to_https_redirect" {
-  count       = var.load_balancer_type == "application" && var.enable_http_to_https_redirect ? 1 : 0
+  count       = var.load_balancer_type == "application" && var.enable_http_to_https_redirect && var.enable_ingress_security_group_rules ? 1 : 0
   type        = "ingress"
   from_port   = 80
   to_port     = 80
@@ -95,7 +95,7 @@ resource "aws_security_group_rule" "allow_port_80_ingress_for_http_to_https_redi
 }
 
 resource "aws_security_group_rule" "allow_port_443_ingress_for_http_to_https_redirect" {
-  count       = var.load_balancer_type == "application" && var.enable_http_to_https_redirect ? 1 : 0
+  count       = var.load_balancer_type == "application" && var.enable_http_to_https_redirect && var.enable_ingress_security_group_rules ? 1 : 0
   type        = "ingress"
   from_port   = 443
   to_port     = 443

--- a/variables.tf
+++ b/variables.tf
@@ -97,6 +97,12 @@ variable "enable_http_to_https_redirect" {
   default     = false
 }
 
+variable "enable_ingress_security_group_rules" {
+  description = "Enable ingress security group rules"
+  type        = bool
+  default     = true
+}
+
 variable "cidr_blocks_redirect" {
   type        = list(string)
   description = "List of CIDR ranges to allow at security group level. Defaults to 0.0.0.0/0"


### PR DESCRIPTION
- Added the ability to not include ingress CIDRs to the Load Balancer Security rules

Signed-off-by: Don Masters <don.masters@umotif.com>

# Description

Please explain the changes you made here and link to any relevant issues.
