### PR TITLE
fix aws alb security groups binding

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "aws_lb" "main" {
   load_balancer_type = var.load_balancer_type
   internal           = var.internal
   subnets            = var.subnets
-  security_groups    = aws_security_group.main[0].id
+  security_groups    = aws_security_group.main.*.id
 
   idle_timeout                     = var.idle_timeout
   enable_deletion_protection       = var.enable_deletion_protection


### PR DESCRIPTION
# Description

Please explain the changes you made here and link to any relevant issues.

This issue has been introduced since commit at: https://github.com/umotif-public/terraform-aws-alb/commit/721450c96caaf8c01e5e703a950d1d1ce603eb52.

The value for attribute alb.security_groups should be a set/array of security groups rather than the first offset - the load balancer should be associated with all of the relevant security groups.

Link to relevant issue: https://github.com/umotif-public/terraform-aws-alb/issues/11.