### PR TITLE
bug fix - turned security group attribute to a set of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 <a name="unreleased"></a>
 ## [Unreleased]
 
-- Upgraded to 5.x compatibility + refactored S3 bucket for ALB security logs
+
+
+<a name="2.2.0"></a>
+## [2.2.0] - 2023-07-31
+
+- Upgraded to 5.x compatibility + refactored S3 bucket for ALB ([#8](https://github.com/umotif-public/terraform-aws-alb/issues/8))
 
 
 <a name="2.1.0"></a>
@@ -77,7 +82,8 @@ All notable changes to this project will be documented in this file.
 - initial module push
 
 
-[Unreleased]: https://github.com/umotif-public/terraform-aws-alb/compare/2.1.0...HEAD
+[Unreleased]: https://github.com/umotif-public/terraform-aws-alb/compare/2.2.0...HEAD
+[2.2.0]: https://github.com/umotif-public/terraform-aws-alb/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/umotif-public/terraform-aws-alb/compare/2.0.0...2.1.0
 [2.0.0]: https://github.com/umotif-public/terraform-aws-alb/compare/1.2.2...2.0.0
 [1.2.2]: https://github.com/umotif-public/terraform-aws-alb/compare/1.2.1...1.2.2

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Module managed by [uMotif](https://github.com/umotif-public/).
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0.11 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.11 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.40.0 |
 
 ## Providers

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,7 @@ resource "aws_lb" "main" {
   load_balancer_type = var.load_balancer_type
   internal           = var.internal
   subnets            = var.subnets
-  security_groups    = aws_security_group.main[0].id
+  security_groups    = [aws_security_group.main[0].id]
 
   idle_timeout                     = var.idle_timeout
   enable_deletion_protection       = var.enable_deletion_protection


### PR DESCRIPTION
# Description

Fixed a bug for AWS provider 4.67 that needed security group ID to be a set of string